### PR TITLE
Bump version to 1.0.4 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.0.4
+
+* Complete singleton pattern for Luffa::Simulator
+* Fixup retriable 1.x to 2.x bridge
+
 ### 1.0.3
 
 Add a bridge between Retriable 1.x and 2.x support

--- a/lib/luffa/version.rb
+++ b/lib/luffa/version.rb
@@ -1,5 +1,5 @@
 module Luffa
-  VERSION = '1.0.3'
+  VERSION = '1.0.4'
 
   # A model of a software release version that can be used to compare two versions.
   #


### PR DESCRIPTION
### 1.0.4

* Complete singleton pattern for Luffa::Simulator
* Fixup retriable 1.x to 2.x bridge