### PR TITLE
Fixup ideviceinstaller wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@
 mkmf.log
 *.gem
 
+*.app
+*.ipa
+
 # rbenv and rvm
 .ruby-version
 .ruby-gemset

--- a/.irbrc
+++ b/.irbrc
@@ -16,6 +16,14 @@ IRB.conf[:SAVE_HISTORY] = 100
 # Store results in home directory with specified file name
 IRB.conf[:HISTORY_FILE] = '.irb-history'
 
+def quiet
+  ENV.delete('DEBUG')
+end
+
+def verbose
+  ENV['DEBUG'] = '1'
+end
+
 module Luffa
   module IRBRC
     def self.message_of_the_day


### PR DESCRIPTION
### Motivation

ideviceinstaller hangs indefinitely when idevice_ids reports duplicate device udids.

Now we have a configurable timeout and retry.