### PR TITLE
Release/2.0.0

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -12,9 +12,36 @@ ARGV.concat [ '--readline',
               'simple']
 
 IRB.conf[:SAVE_HISTORY] = 100
-
-# Store results in home directory with specified file name
 IRB.conf[:HISTORY_FILE] = '.irb-history'
+
+IRB.conf[:AUTO_INDENT] = true
+
+IRB.conf[:PROMPT][:LUFFA] = {
+  :PROMPT_I => "luffa #{Luffa::VERSION}> ",
+  :PROMPT_N => "luffa #{Luffa::VERSION}> ",
+  :PROMPT_S => nil,
+  :PROMPT_C => "> ",
+  :AUTO_INDENT => true,
+  :RETURN => "%s\n"
+}
+
+IRB.conf[:PROMPT_MODE] = :LUFFA
+
+begin
+  require 'pry'
+  Pry.config.history.should_save = false
+  Pry.config.history.should_load = false
+  require 'pry-nav'
+rescue LoadError => _
+
+end
+
+puts ''
+puts '#       =>  Useful Methods  <=          #'
+puts '> quiet       => Turn off DEBUG logging.'
+puts '> verbose     => Turn on DEBUG logging.'
+puts ''
+
 
 def quiet
   ENV.delete('DEBUG')
@@ -38,3 +65,4 @@ module Luffa
 end
 
 Luffa::IRBRC.message_of_the_day
+

--- a/.pryrc
+++ b/.pryrc
@@ -1,0 +1,8 @@
+begin
+  require 'pry'
+  Pry.config.history.should_save = false
+  Pry.config.history.should_load = false
+  require 'pry-nav'
+rescue LoadError => _
+
+end

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,6 @@ script:
 
 notifications:
   email: false
+  slack:
+    rooms:
+      secure: Uw8FBYmJjNZhLmEB/2T4VYfm2QrbCjErXiKS86J8VRt2pEC85cCC/ZGzgL+4l7gSOuRf1JpiFYqKMjTHO1kvLGRdDuCTZoOgq2KqXmiratV3jwwLqinBmQSA4aUMuqQTjBB15D80XkoXPVYYoH/kwiKjffMCpKvd6OIIdY2BrNU=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 2.0.0
+
+* Requires ruby >= 2.0
+* Allow `luffa authorize` to be run anywhere
+
+
 ### 1.1.0
 
 * Respond to deprecated RunLoop::XCTools

--- a/Guardfile
+++ b/Guardfile
@@ -10,7 +10,15 @@ end
 # Short-running examples should be placed in spec/lib
 # Long-running examples and examples that steal the application focus
 # (e.g. launch the simulator) should be placed in spec/integration.
-guard :rspec, cmd: 'bundle exec rspec', spec_paths: ['spec/lib', 'spec/bin'] do
+options =
+      {
+            cmd: 'bundle exec rspec',
+            spec_paths: ['spec/lib'],
+            failed_mode: :focus,
+            all_after_pass: true,
+            all_on_start: true
+      }
+guard(:rspec, options) do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/luffa/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
   watch(%r{^spec/bin/.+_spec\.rb$})

--- a/lib/luffa/ios/ideviceinstaller.rb
+++ b/lib/luffa/ios/ideviceinstaller.rb
@@ -36,7 +36,7 @@ module Luffa
     end
 
     # Can only be called when RunLoop is available.
-    def self.physical_devices_for_testing(xcode_tools)
+    def self.physical_devices_for_testing(instruments)
       # Xcode 6 + iOS 8 - devices on the same network, whether development or
       # not, appear when calling $ xcrun instruments -s devices. For the
       # purposes of testing, we will only try to connect to devices that are
@@ -44,7 +44,7 @@ module Luffa
       #
       # Also idevice_id, which ideviceinstaller relies on, will sometimes report
       # devices 2x which will cause ideviceinstaller to fail.
-      devices = xcode_tools.instruments(:devices)
+      devices = instruments.physical_devices
       if IDeviceInstaller.idevice_id_available?
         white_list = `#{self.idevice_id_bin_path} -l`.strip.split("\n")
         devices.select do | device |

--- a/lib/luffa/version.rb
+++ b/lib/luffa/version.rb
@@ -1,5 +1,5 @@
 module Luffa
-  VERSION = '1.1.0'
+  VERSION = "2.0.0"
 
   # A model of a software release version that can be used to compare two versions.
   #

--- a/spec/lib/patches/retriable_spec.rb
+++ b/spec/lib/patches/retriable_spec.rb
@@ -21,19 +21,19 @@ describe Luffa::RetryOpts do
       it ':tries is not allowed' do
         expect {
           retry_module.tries_and_interval(3, 4, {:tries => 3})
-        }.to raise_error
+        }.to raise_error RuntimeError
       end
 
       it ':interval is not allowed' do
         expect {
           retry_module.tries_and_interval(3, 4, {:interval => 3})
-        }.to raise_error
+        }.to raise_error RuntimeError
       end
 
       it ':intervals is not allowed' do
         expect {
           retry_module.tries_and_interval(3, 4, {:intervals => 3})
-        }.to raise_error
+        }.to raise_error RuntimeError
       end
     end
 


### PR DESCRIPTION
### 2.0.0                                                                                                                                                                                                                                               * Requires ruby >= 2.0                                                                                                      
* Allow `luffa authorize` to be run anywhere